### PR TITLE
write_gif() ImageMagick fix

### DIFF
--- a/moviepy/video/io/gif_writers.py
+++ b/moviepy/video/io/gif_writers.py
@@ -55,8 +55,8 @@ def write_gif_with_tempfiles(clip, filename, fps=None, program= 'ImageMagick',
               "-loop" , "%d"%loop,
               "%s_GIFTEMP*.png"%fileName,
               "-coalesce",
-              "-layers", "%s"%opt,
               "-fuzz", "%02d"%fuzz + "%",
+              "-layers", "%s"%opt,
               ]+(["-colors", "%d"%colors] if colors is not None else [])+[
               filename]
 
@@ -203,8 +203,8 @@ def write_gif(clip, filename, fps=None, program= 'ImageMagick',
 
         if opt:
 
-            cmd3 = [get_setting("IMAGEMAGICK_BINARY"), '-', '-layers', opt,
-                    '-fuzz', '%d'%fuzz+'%'
+            cmd3 = [get_setting("IMAGEMAGICK_BINARY"), '-',
+                    '-fuzz', '%d'%fuzz+'%', '-layers', opt
                    ]+(["-colors", "%d"%colors] if colors is not None else [])+[
                    filename]
 


### PR DESCRIPTION
write_gif() fuzz argument had no visible influence on output file due to wrong order of params passsed to ImageMagick, these changes fixed this issue. Optimizations work now too.
Changes are made accordingly to ImageMagick usage documentation.
test snippet:
`
from moviepy.editor import *

clip = (VideoFileClip(infile, audio=False))
clip.write_gif('test.gif', fps=15, program='ImageMagick', fuzz=40, opt='optimize-frame')
`




<!-- Please tick when you have done these. They don't need to all be completed before the PR is created -->
- [x] If this is a bugfix, I have provided code that clearly demonstrates the problem and that works when used with this PR
- [ ] I have added a test to the test suite, if necessary
- [ ] I have properly documented new or changed features in the documention, or the docstrings
- [ ] I have properly documented unusual changes to the code in the comments around it
- [x] I have made note of any breaking/backwards incompatible changes
