### PR TITLE
write_gif() using ImageMagick bugfix

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -465,8 +465,15 @@ class VideoClip(Clip):
                                      dispose=dispose, colors=colors,
                                      logger=logger)
         else:
+            # convert imageio opt variable to something that can be used with
+            # ImageMagick
+            opt1 = opt
+            if opt1 == 'nq':
+                opt1 ='optimizeplus'
+            else:
+                opt1 ='OptimizeTransparency'
             write_gif(self, filename, fps=fps, program=program,
-                      opt=opt, fuzz=fuzz, verbose=verbose, loop=loop,
+                      opt=opt1, fuzz=fuzz, verbose=verbose, loop=loop,
                       dispose=dispose, colors=colors,
                       logger=logger)
 


### PR DESCRIPTION
Fixes Zulko/moviepy#113

Fixes bug when exporting to gif using ImageMagick with no "opt" parameter specified ie `opt=OptimizePlus` does not produce output file while stating that [MoviePy] >>>> File /.../test.gif is ready!

test snippet:
`
from moviepy.editor import *

infile = "yourinputfile"
clip = (VideoFileClip(infile, audio=False))
clip.write_gif('test.gif', program= 'ImageMagick', fuzz=40)
`

<!-- Please tick when you have done these. They don't need to all be completed before the PR is created -->
- [x] If this is a bugfix, I have provided code that clearly demonstrates the problem and that works when used with this PR
- [ ] I have added a test to the test suite, if necessary
- [ ] I have properly documented new or changed features in the documention, or the docstrings
- [ ] I have properly documented unusual changes to the code in the comments around it
- [ ] I have made note of any breaking/backwards incompatible changes
